### PR TITLE
Fix conversation id parsing and add regression tests

### DIFF
--- a/custom_handler.py
+++ b/custom_handler.py
@@ -41,7 +41,7 @@ class OpenAIResponsesBridge(CustomLLM):
     def _get_conversation_id(messages: list[dict[str, Any]]) -> str | None:
         for message in messages:
             if message["role"] == "user":
-                match = re.search(r"<conv_id=(.*)>", str(message["content"]))
+                match = re.search(r"<conv_id=([^>]+)>", str(message["content"]))
 
                 if match:
                     return match.group(1)

--- a/tests/test_conversation_id.py
+++ b/tests/test_conversation_id.py
@@ -1,0 +1,32 @@
+import unittest
+
+from custom_handler import OpenAIResponsesBridge
+
+
+class ConversationIdTests(unittest.TestCase):
+    def test_get_conversation_id_basic(self) -> None:
+        messages = [
+            {"role": "user", "content": "<conv_id=abc123>\nHello"},
+        ]
+
+        self.assertEqual(
+            OpenAIResponsesBridge._get_conversation_id(messages),
+            "abc123",
+        )
+
+    def test_get_conversation_id_with_inline_gt_characters(self) -> None:
+        messages = [
+            {
+                "role": "user",
+                "content": "<conv_id=abc123> I'm curious why 5 > 3 holds.",
+            },
+        ]
+
+        self.assertEqual(
+            OpenAIResponsesBridge._get_conversation_id(messages),
+            "abc123",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- tighten the <conv_id=...> regex to avoid capturing trailing text when user messages contain additional > characters
- add lightweight unit tests covering basic and inline greater-than scenarios for conversation id extraction

## Testing
- python -m unittest tests.test_conversation_id

------
https://chatgpt.com/codex/tasks/task_e_68cbac48ea508332a1496aef8c020f95