### PR TITLE
Implement agent router for LiteLLM proxy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,7 @@
 model_list:
+  - model_name: x-router
+    litellm_params:
+      model: agent-router/x-router
   - model_name: x-gpt-5
     litellm_params:
       model: openai-bridge/x-gpt-5
@@ -189,6 +192,8 @@ litellm_settings:
       custom_handler: custom_handler.openai_responses_bridge
     - provider: perplexity-bridge
       custom_handler: custom_handler.perplexity_bridge
+    - provider: agent-router
+      custom_handler: custom_handler.agent_router
 
 
 general_settings:

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+# shellcheck source=/dev/null
 . ./.venv/bin/activate
 
+# shellcheck source=/dev/null
 [ -f .env ] && set -a && . ./.env && set +a
 
 litellm \

--- a/test.py
+++ b/test.py
@@ -45,7 +45,7 @@ def test_chat_stream_direct() -> None:
         stream=True,
     )
 
-    for event in stream:
+    for _ in stream:
         pass
 
     direct_duration = time.time() - start_time


### PR DESCRIPTION
## Summary
- add an agent router custom handler that classifies the first user turn with `gpt-5-mini` and forwards subsequent traffic to the chosen `x-` model while tagging the first response
- wire the router into the LiteLLM configuration with a new `x-router` model alias and provider mapping
- tidy supporting scripts by silencing shellcheck false positives and quieting lint warnings

## Testing
- ./lint.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc4882507c8332a2821bb78f6df422